### PR TITLE
Config file, column selection, treeview expansion memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ file(GLOB NIXVIEW_UI *.ui
   infowidget/*.ui 
   plotter/*.ui 
   views/*.ui 
-  options/.*ui
+  options/*.ui
   options/viewoptions/*.ui)
 
 file(GLOB NIXVIEW_RES *.qrc 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,33 @@ include_directories(AFTER ${Boost_INCLUDE_DIR})
 # Configure the target
 include_directories(${CMAKE_BINARY_DIR})
 
-file(GLOB NIXVIEW_SOURCES *.cpp infowidget/*.cpp plotter/*.cpp model/*.cpp views/*.cpp filter/*.cpp)
-file(GLOB NIXVIEW_INCLUDES *.hpp infowidget/*.hpp plotter/*.h model/*.hpp views/*.hpp filter/*.hpp)
-file(GLOB NIXVIEW_UI *.ui infowidget/*.ui plotter/*.ui views/*ui)
-file(GLOB NIXVIEW_RES *.qrc infowidget/*.qrc)
+file(GLOB NIXVIEW_SOURCES *.cpp 
+  infowidget/*.cpp 
+  plotter/*.cpp 
+  model/*.cpp 
+  views/*.cpp 
+  filter/*.cpp 
+  options/*.cpp
+  options/viewoptions/*.cpp)
+
+file(GLOB NIXVIEW_INCLUDES *.hpp 
+  infowidget/*.hpp 
+  plotter/*.h 
+  model/*.hpp 
+  views/*.hpp 
+  filter/*.hpp 
+  options/*.hpp
+  options/viewoptions/*.hpp)
+
+file(GLOB NIXVIEW_UI *.ui 
+  infowidget/*.ui 
+  plotter/*.ui 
+  views/*.ui 
+  options/.*ui
+  options/viewoptions/*.ui)
+
+file(GLOB NIXVIEW_RES *.qrc 
+  infowidget/*.qrc)
 
 QT5_WRAP_UI(NIXVIEW_UI_HDRS ${NIXVIEW_UI})
 QT5_ADD_RESOURCES(NIXVIEW_RES_SOURCES ${NIXVIEW_RES})

--- a/MainViewWidget.cpp
+++ b/MainViewWidget.cpp
@@ -120,13 +120,19 @@ void MainViewWidget::connect_widgets()
     // tree widget expanded/collapsed
     QObject::connect(rtv->get_tree_view(), SIGNAL(expanded(QModelIndex)), rtv, SLOT(resize_to_content(QModelIndex)));
     QObject::connect(rtv->get_tree_view(), SIGNAL(collapsed(QModelIndex)), rtv, SLOT(resize_to_content(QModelIndex)));
+    QObject::connect(rtv->get_tree_view(), SIGNAL(expanded(QModelIndex)), rtv, SLOT(set_current_depth_expanded(QModelIndex)));
+    QObject::connect(rtv->get_tree_view(), SIGNAL(collapsed(QModelIndex)), rtv, SLOT(set_current_depth_collapsed(QModelIndex)));
 
     // filter
     QObject::connect(ui->cmbx_filter, SIGNAL(currentIndexChanged(QString)), nix_proxy_model, SLOT(set_rough_filter(QString)));
+    QObject::connect(ui->cmbx_filter, SIGNAL(currentIndexChanged(QString)), rtv, SLOT(expand_collapse(QString)));
     QObject::connect(ui->line_edit_filter, SIGNAL(textChanged(QString)), nix_proxy_model, SLOT(set_fine_filter(QString)));
+    QObject::connect(ui->line_edit_filter, SIGNAL(textChanged(QString)), rtv, SLOT(expand_collapse(QString)));
     QObject::connect(ui->cbx_filter, SIGNAL(toggled(bool)), nix_proxy_model, SLOT(set_case_sensitivity(bool)));
+    QObject::connect(ui->cbx_filter, SIGNAL(toggled(bool)), rtv, SLOT(expand_collapse(bool)));
 
     QObject::connect(shortcut_filter, SIGNAL(activated()), ui->line_edit_filter, SLOT(setFocus()));
+
 
     // ALSO CHECK CONNECTIONS IN InfoWidget.cpp
 }

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -20,7 +20,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent),
     file_progress->setVisible(false);
 
     ow = new OptionsWidget();
-//    ow->show();
 }
 
 void MainWindow::connect_widgets() {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -11,8 +11,8 @@
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent),
     ui(new Ui::MainWindow) {
 
-    QCoreApplication::setOrganizationName("G-Node");
-    QCoreApplication::setApplicationName("NixView");
+    QCoreApplication::setOrganizationName("g-node");
+    QCoreApplication::setApplicationName("nixview");
 
     ui->setupUi(this);
     mvw_is_set = false;
@@ -29,6 +29,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent),
 void MainWindow::connect_widgets() {
     QObject::connect(this, SIGNAL(emit_view_change(int)), mvw, SLOT(set_view(int)));
     QObject::connect(mvw, SIGNAL(emit_current_qml(QModelIndex)), this, SLOT(activate_plot(QModelIndex)));
+
+    QObject::connect(ow->tree_view_options, SIGNAL(emit_rtv_column_display_changed()), mvw->get_rtv(), SLOT(hide_columns()));
 }
 
 MainWindow::~MainWindow() {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -18,6 +18,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent),
     ui->statusBar->addPermanentWidget(file_label, 1);
     ui->statusBar->addPermanentWidget(file_progress, 10);
     file_progress->setVisible(false);
+
+    ow = new OptionsWidget();
+//    ow->show();
 }
 
 void MainWindow::connect_widgets() {
@@ -30,12 +33,19 @@ MainWindow::~MainWindow() {
 }
 
 // slots
-void MainWindow::on_actionTree_triggered() {
+void MainWindow::on_actionTree_triggered()
+{
     emit emit_view_change(VIEW_TREE);
 }
 
-void MainWindow::on_actionColumn_triggered() {
+void MainWindow::on_actionColumn_triggered()
+{
     emit emit_view_change(VIEW_COLUMN);
+}
+
+void MainWindow::on_actionProperties_triggered()
+{
+    ow->show();
 }
 
 void MainWindow::activate_plot(QModelIndex qml) {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -10,6 +10,10 @@
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent),
     ui(new Ui::MainWindow) {
+
+    QCoreApplication::setOrganizationName("G-Node");
+    QCoreApplication::setApplicationName("NixView");
+
     ui->setupUi(this);
     mvw_is_set = false;
     file_label = new QLabel(this);

--- a/MainWindow.hpp
+++ b/MainWindow.hpp
@@ -8,6 +8,7 @@
 #include <QProgressBar>
 #include <nix.hpp>
 #include "MainViewWidget.hpp"
+#include "options/OptionsWidget.hpp"
 
 class QVariant;
 
@@ -26,6 +27,7 @@ public:
 public slots:
     void on_actionTree_triggered();
     void on_actionColumn_triggered();
+    void on_actionProperties_triggered();
     void activate_plot(QModelIndex qml);
     void open_file();
     void show_about();
@@ -39,6 +41,7 @@ private:
     Ui::MainWindow *ui;
     MainViewWidget* mvw;
     bool mvw_is_set;
+    OptionsWidget *ow;
     void connect_widgets();
     QModelIndex selected_qml;
     QLabel* file_label;

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -54,7 +54,7 @@
      <x>0</x>
      <y>0</y>
      <width>1400</width>
-     <height>27</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -69,6 +69,7 @@
     <property name="title">
      <string>&amp;Options</string>
     </property>
+    <addaction name="actionProperties"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -235,6 +236,11 @@
   <action name="actionColumn">
    <property name="text">
     <string>&amp;Column</string>
+   </property>
+  </action>
+  <action name="actionProperties">
+   <property name="text">
+    <string>&amp;Properties</string>
    </property>
   </action>
  </widget>

--- a/NixView.pro
+++ b/NixView.pro
@@ -40,7 +40,8 @@ SOURCES += main.cpp\
     model/NixModelItem.cpp \
     entitydescriptor.cpp \
     options/OptionsWidget.cpp \
-    options/OptionsTabWidget.cpp
+    options/OptionsTabWidget.cpp \
+    options/viewoptions/TreeViewOptions.cpp
 
 HEADERS  += MainWindow.hpp \
     MainViewWidget.hpp \
@@ -64,7 +65,8 @@ HEADERS  += MainWindow.hpp \
     model/NixModelItem.hpp \
     entitydescriptor.h \
     options/OptionsWidget.hpp \
-    options/OptionsTabWidget.hpp
+    options/OptionsTabWidget.hpp \
+    options/viewoptions/TreeViewOptions.hpp
 
 FORMS    += MainWindow.ui \
     MainViewWidget.ui \
@@ -79,7 +81,8 @@ FORMS    += MainWindow.ui \
     plotwidget.ui \
     plotter/categoryplotter.ui \
     views/ColumnView.ui \
-    options/OptionsWidget.ui
+    options/OptionsWidget.ui \
+    options/viewoptions/TreeViewOptions.ui
 
 #standard windows folder?
 #win32:CONFIG(release, debug|release): LIBS += /usr/local/lib/release/ -lnix

--- a/NixView.pro
+++ b/NixView.pro
@@ -38,7 +38,9 @@ SOURCES += main.cpp\
     views/ColumnView.cpp \
     filter/NixProxyModel.cpp \
     model/NixModelItem.cpp \
-    entitydescriptor.cpp
+    entitydescriptor.cpp \
+    options/OptionsWidget.cpp \
+    options/OptionsTabWidget.cpp
 
 HEADERS  += MainWindow.hpp \
     MainViewWidget.hpp \
@@ -60,7 +62,9 @@ HEADERS  += MainWindow.hpp \
     views/ColumnView.hpp \
     filter/NixProxyModel.hpp \
     model/NixModelItem.hpp \
-    entitydescriptor.h
+    entitydescriptor.h \
+    options/OptionsWidget.hpp \
+    options/OptionsTabWidget.hpp
 
 FORMS    += MainWindow.ui \
     MainViewWidget.ui \
@@ -74,7 +78,8 @@ FORMS    += MainWindow.ui \
     plotter/lineplotter.ui \
     plotwidget.ui \
     plotter/categoryplotter.ui \
-    views/ColumnView.ui
+    views/ColumnView.ui \
+    options/OptionsWidget.ui
 
 #standard windows folder?
 #win32:CONFIG(release, debug|release): LIBS += /usr/local/lib/release/ -lnix

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -61,5 +61,7 @@ Q_DECLARE_METATYPE(nix::Source)
 #define FILTER_EXP_NAME_CONTAINS "Name contains"
 #define FILTER_EXP_NIXTYPE_CONTAINS "Nix Type contains"
 
-
+// define setting expressions
+#define S_RAWTREEVIEW "rawtreeview"
+#define S_COLUMNS "columns"
 

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -11,6 +11,19 @@ Q_DECLARE_METATYPE(nix::MultiTag)
 Q_DECLARE_METATYPE(nix::Feature)
 Q_DECLARE_METATYPE(nix::Source)
 
+// define model headers
+#define MODEL_HEADER_NAME "Name"
+#define MODEL_HEADER_NIXTYPE "Nix Type"
+#define MODEL_HEADER_STORAGETYPE "Storage Type"
+#define MODEL_HEADER_DATATYPE "Data Type"
+#define MODEL_HEADER_SHAPE "Shape"
+#define MODEL_HEADER_ID "ID"
+#define MODEL_HEADER_CREATEDAT "Created at"
+#define MODEL_HEADER_UPDATEDAT "Updated at"
+#define MODEL_HEADER_VALUE "Value"
+#define MODEL_HEADER_UNERTAINTY "Uncertainty"
+#define MODEL_HEADER_ROOTCHILDLINK "root_child_link"
+
 // define strings regarding NIX for consistent use
 #define NIX_STRING_BLOCK "Block"
 #define NIX_STRING_GROUP "Group"
@@ -47,4 +60,6 @@ Q_DECLARE_METATYPE(nix::Source)
 #define FILTER_EXP_MULTITAG "is MultiTag"
 #define FILTER_EXP_NAME_CONTAINS "Name contains"
 #define FILTER_EXP_NIXTYPE_CONTAINS "Nix Type contains"
-//TODO more expressions
+
+
+

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -21,7 +21,7 @@ Q_DECLARE_METATYPE(nix::Source)
 #define MODEL_HEADER_CREATEDAT "Created at"
 #define MODEL_HEADER_UPDATEDAT "Updated at"
 #define MODEL_HEADER_VALUE "Value"
-#define MODEL_HEADER_UNERTAINTY "Uncertainty"
+#define MODEL_HEADER_UNCERTAINTY "Uncertainty"
 #define MODEL_HEADER_ROOTCHILDLINK "root_child_link"
 
 // define strings regarding NIX for consistent use

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -63,5 +63,5 @@ Q_DECLARE_METATYPE(nix::Source)
 
 // define setting expressions
 #define S_RAWTREEVIEW "rawtreeview"
-#define S_COLUMNS "columns"
+#define S_COLUMNSHIDDEN "columnshidden"
 

--- a/infowidget/MetaDataPanel.ui
+++ b/infowidget/MetaDataPanel.ui
@@ -29,6 +29,9 @@
    </item>
    <item>
     <widget class="QTreeView" name="treeView">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>

--- a/infowidget/TagPanel.ui
+++ b/infowidget/TagPanel.ui
@@ -64,6 +64,9 @@
    </item>
    <item>
     <widget class="QTreeWidget" name="treeWidget_references">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>
@@ -103,6 +106,9 @@
    </item>
    <item>
     <widget class="QTreeWidget" name="treeWidget_features">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>

--- a/model/NixDataModel.cpp
+++ b/model/NixDataModel.cpp
@@ -7,17 +7,17 @@
 
 NixDataModel::NixDataModel() : QStandardItemModel(){
     RowStrings headers;
-    headers << "Name"               //  0
-            << "Nix Type"           //  1
-            << "Storage Type"       //  2
-            << "Data Type"          //  3
-            << "Shape"              //  4
-            << "ID"                 //  5
-            << "CreatedAt"          //  6
-            << "UpdatedAt"          //  7
-            << "Value"              //  8
-            << "Uncertainty"        //  9
-            << "root_child_link";   // 10
+    headers << MODEL_HEADER_NAME               //  0
+            << MODEL_HEADER_NIXTYPE            //  1
+            << MODEL_HEADER_STORAGETYPE        //  2
+            << MODEL_HEADER_DATATYPE           //  3
+            << MODEL_HEADER_SHAPE              //  4
+            << MODEL_HEADER_ID                 //  5
+            << MODEL_HEADER_CREATEDAT          //  6
+            << MODEL_HEADER_UPDATEDAT          //  7
+            << MODEL_HEADER_VALUE              //  8
+            << MODEL_HEADER_UNERTAINTY         //  9
+            << MODEL_HEADER_ROOTCHILDLINK;     // 10
     setHorizontalHeaderLabels(headers);
     num_columns = headers.size();
 }

--- a/model/NixDataModel.cpp
+++ b/model/NixDataModel.cpp
@@ -15,7 +15,7 @@ NixDataModel::NixDataModel() : QStandardItemModel(){
             << MODEL_HEADER_CREATEDAT          //  6
             << MODEL_HEADER_UPDATEDAT          //  7
             << MODEL_HEADER_VALUE              //  8
-            << MODEL_HEADER_UNERTAINTY         //  9
+            << MODEL_HEADER_UNCERTAINTY         //  9
             << MODEL_HEADER_ROOTCHILDLINK;     // 10
     setHorizontalHeaderLabels(headers);
     num_columns = headers.size();

--- a/model/NixDataModel.cpp
+++ b/model/NixDataModel.cpp
@@ -6,7 +6,6 @@
 #include <math.h>
 
 NixDataModel::NixDataModel() : QStandardItemModel(){
-    RowStrings headers;
     headers << MODEL_HEADER_NAME               //  0
             << MODEL_HEADER_NIXTYPE            //  1
             << MODEL_HEADER_STORAGETYPE        //  2

--- a/model/NixDataModel.hpp
+++ b/model/NixDataModel.hpp
@@ -23,8 +23,12 @@ public:
     void nix_file_to_model(const nix::File &nix_file);
     int progress();
 
+    const RowStrings get_headers() const {return headers; }
+
 
 private:
+    RowStrings headers;
+
     double scan_progress = 0.0;
     QString s_to_q(std::string);
     template<typename T>

--- a/options/OptionsTabWidget.cpp
+++ b/options/OptionsTabWidget.cpp
@@ -1,0 +1,8 @@
+#include "OptionsTabWidget.hpp"
+
+OptionsTabWidget::OptionsTabWidget() :
+    QTabWidget()
+{
+    setTabPosition(QTabWidget::West);
+}
+

--- a/options/OptionsTabWidget.hpp
+++ b/options/OptionsTabWidget.hpp
@@ -1,0 +1,16 @@
+#ifndef OPTIONSTABWIDGET_H
+#define OPTIONSTABWIDGET_H
+
+#include <QTabWidget>
+
+class OptionsTabWidget : QTabWidget
+{
+    Q_OBJECT
+
+public:
+    OptionsTabWidget();
+
+friend class OptionsWidget;
+};
+
+#endif // OPTIONSTABWIDGET_H

--- a/options/OptionsWidget.cpp
+++ b/options/OptionsWidget.cpp
@@ -48,7 +48,7 @@ OptionsWidget::OptionsWidget(QWidget *parent) :
     view_tab_widget->addTab(tree_view_options, "TreeView");
 
     tw->addTab(view_tab_widget, "Views");
-    tw->addTab(new DescriptionPanel(), "Other Stuff");
+//    tw->addTab(new DescriptionPanel(), "Other Stuff");
 
     ui->verticalLayout->addWidget(tw);
 }

--- a/options/OptionsWidget.cpp
+++ b/options/OptionsWidget.cpp
@@ -1,0 +1,54 @@
+#include "OptionsWidget.hpp"
+#include "ui_OptionsWidget.h"
+#include <QProxyStyle>
+#include "infowidget/DescriptionPanel.hpp"
+#include "infowidget/TagPanel.hpp"
+
+class HorizontalTabBarStyle : public QProxyStyle
+{
+public:
+    QSize sizeFromContents(ContentsType type, const QStyleOption *option,
+                           const QSize &size, const QWidget *widget) const
+    {
+        QSize s = QProxyStyle::sizeFromContents(type, option, size, widget);
+        if (type == QStyle::CT_TabBarTab)
+            s.transpose();
+        return s;
+    }
+
+    void drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
+    {
+        if (element == CE_TabBarTabLabel)
+        {
+            if (const QStyleOptionTab *tab = qstyleoption_cast<const QStyleOptionTab *>(option))
+            {
+                QStyleOptionTab opt(*tab);
+                opt.shape = QTabBar::RoundedNorth;
+                QProxyStyle::drawControl(element, &opt, painter, widget);
+                return;
+            }
+        }
+        QProxyStyle::drawControl(element, option, painter, widget);
+    }
+};
+
+
+OptionsWidget::OptionsWidget(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::OptionsWidget)
+{
+    ui->setupUi(this);
+    setWindowTitle("Options");
+
+    tw = new OptionsTabWidget();
+    tw->tabBar()->setStyle(new HorizontalTabBarStyle);
+    tw->addTab(new DescriptionPanel(), "Views");
+    tw->addTab(new TagPanel(), "Other Stuff");
+
+    ui->verticalLayout->addWidget(tw);
+}
+
+OptionsWidget::~OptionsWidget()
+{
+    delete ui;
+}

--- a/options/OptionsWidget.cpp
+++ b/options/OptionsWidget.cpp
@@ -2,7 +2,7 @@
 #include "ui_OptionsWidget.h"
 #include <QProxyStyle>
 #include "infowidget/DescriptionPanel.hpp"
-#include "infowidget/TagPanel.hpp"
+#include "options/viewoptions/TreeViewOptions.hpp"
 
 class HorizontalTabBarStyle : public QProxyStyle
 {
@@ -42,8 +42,13 @@ OptionsWidget::OptionsWidget(QWidget *parent) :
 
     tw = new OptionsTabWidget();
     tw->tabBar()->setStyle(new HorizontalTabBarStyle);
-    tw->addTab(new DescriptionPanel(), "Views");
-    tw->addTab(new TagPanel(), "Other Stuff");
+
+    // view options
+    QTabWidget *view_tab_widget = new QTabWidget();
+    view_tab_widget->addTab(new TreeViewOptions(), "TreeView");
+
+    tw->addTab(view_tab_widget, "Views");
+    tw->addTab(new DescriptionPanel(), "Other Stuff");
 
     ui->verticalLayout->addWidget(tw);
 }

--- a/options/OptionsWidget.cpp
+++ b/options/OptionsWidget.cpp
@@ -2,7 +2,6 @@
 #include "ui_OptionsWidget.h"
 #include <QProxyStyle>
 #include "infowidget/DescriptionPanel.hpp"
-#include "options/viewoptions/TreeViewOptions.hpp"
 
 class HorizontalTabBarStyle : public QProxyStyle
 {
@@ -45,7 +44,8 @@ OptionsWidget::OptionsWidget(QWidget *parent) :
 
     // view options
     QTabWidget *view_tab_widget = new QTabWidget();
-    view_tab_widget->addTab(new TreeViewOptions(), "TreeView");
+    tree_view_options = new TreeViewOptions();
+    view_tab_widget->addTab(tree_view_options, "TreeView");
 
     tw->addTab(view_tab_widget, "Views");
     tw->addTab(new DescriptionPanel(), "Other Stuff");

--- a/options/OptionsWidget.cpp
+++ b/options/OptionsWidget.cpp
@@ -38,7 +38,7 @@ OptionsWidget::OptionsWidget(QWidget *parent) :
     ui(new Ui::OptionsWidget)
 {
     ui->setupUi(this);
-    setWindowTitle("Options");
+    setWindowTitle("Properties");
 
     tw = new OptionsTabWidget();
     tw->tabBar()->setStyle(new HorizontalTabBarStyle);

--- a/options/OptionsWidget.hpp
+++ b/options/OptionsWidget.hpp
@@ -1,0 +1,25 @@
+#ifndef OPTIONSWIDGET_HPP
+#define OPTIONSWIDGET_HPP
+
+#include <QWidget>
+#include <QTabWidget>
+#include "options/OptionsTabWidget.hpp"
+
+namespace Ui {
+class OptionsWidget;
+}
+
+class OptionsWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit OptionsWidget(QWidget *parent = 0);
+    ~OptionsWidget();
+
+private:
+    Ui::OptionsWidget *ui;
+    OptionsTabWidget *tw;
+};
+
+#endif // OPTIONSWIDGET_HPP

--- a/options/OptionsWidget.hpp
+++ b/options/OptionsWidget.hpp
@@ -4,6 +4,7 @@
 #include <QWidget>
 #include <QTabWidget>
 #include "options/OptionsTabWidget.hpp"
+#include "options/viewoptions/TreeViewOptions.hpp"
 
 namespace Ui {
 class OptionsWidget;
@@ -20,6 +21,9 @@ public:
 private:
     Ui::OptionsWidget *ui;
     OptionsTabWidget *tw;
+    TreeViewOptions *tree_view_options;
+
+friend class MainWindow;
 };
 
 #endif // OPTIONSWIDGET_HPP

--- a/options/OptionsWidget.ui
+++ b/options/OptionsWidget.ui
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OptionsWidget</class>
+ <widget class="QWidget" name="OptionsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>795</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/options/viewoptions/TreeViewOptions.cpp
+++ b/options/viewoptions/TreeViewOptions.cpp
@@ -19,7 +19,7 @@ TreeViewOptions::TreeViewOptions(QWidget *parent) :
     ui->checkBox_createdat->setText(QString(MODEL_HEADER_CREATEDAT));
     ui->checkBox_updatedat->setText(QString(MODEL_HEADER_UPDATEDAT));
     ui->checkBox_value->setText(QString(MODEL_HEADER_VALUE));
-    ui->checkBox_uncertainty->setText(QString(MODEL_HEADER_UNERTAINTY));
+    ui->checkBox_uncertainty->setText(QString(MODEL_HEADER_UNCERTAINTY));
 
     load_settings();
 
@@ -42,7 +42,7 @@ void TreeViewOptions::load_settings()
     ui->checkBox_createdat->setChecked(!(settings->value(MODEL_HEADER_CREATEDAT, default_hidden_columns.contains(MODEL_HEADER_CREATEDAT) ? true : false).toBool()));
     ui->checkBox_updatedat->setChecked(!(settings->value(MODEL_HEADER_UPDATEDAT, default_hidden_columns.contains(MODEL_HEADER_UPDATEDAT) ? true : false).toBool()));
     ui->checkBox_value->setChecked(!(settings->value(MODEL_HEADER_VALUE, default_hidden_columns.contains(MODEL_HEADER_VALUE) ? true : false).toBool()));
-    ui->checkBox_uncertainty->setChecked(!(settings->value(MODEL_HEADER_UNERTAINTY, default_hidden_columns.contains(MODEL_HEADER_UNERTAINTY) ? true : false).toBool()));
+    ui->checkBox_uncertainty->setChecked(!(settings->value(MODEL_HEADER_UNCERTAINTY, default_hidden_columns.contains(MODEL_HEADER_UNCERTAINTY) ? true : false).toBool()));
 
     settings->endGroup();
     settings->endGroup();
@@ -51,6 +51,15 @@ void TreeViewOptions::load_settings()
 void TreeViewOptions::connect_widgets()
 {
     QObject::connect(ui->checkBox_name, SIGNAL(clicked(bool)), this, SLOT(set_name_column_hidden(bool)));
+    QObject::connect(ui->checkBox_nixtype, SIGNAL(clicked(bool)), this, SLOT(set_nixtype_column_hidden(bool)));
+    QObject::connect(ui->checkBox_storagetype, SIGNAL(clicked(bool)), this, SLOT(set_storagetype_column_hidden(bool)));
+    QObject::connect(ui->checkBox_datatype, SIGNAL(clicked(bool)), this, SLOT(set_datatype_column_hidden(bool)));
+    QObject::connect(ui->checkBox_shape, SIGNAL(clicked(bool)), this, SLOT(set_shape_column_hidden(bool)));
+    QObject::connect(ui->checkBox_id, SIGNAL(clicked(bool)), this, SLOT(set_id_column_hidden(bool)));
+    QObject::connect(ui->checkBox_createdat, SIGNAL(clicked(bool)), this, SLOT(set_createdat_column_hidden(bool)));
+    QObject::connect(ui->checkBox_updatedat, SIGNAL(clicked(bool)), this, SLOT(set_updatedat_column_hidden(bool)));
+    QObject::connect(ui->checkBox_value, SIGNAL(clicked(bool)), this, SLOT(set_value_column_hidden(bool)));
+    QObject::connect(ui->checkBox_uncertainty, SIGNAL(clicked(bool)), this, SLOT(set_uncertainty_column_hidden(bool)));
 }
 
 void TreeViewOptions::set_name_column_hidden(bool b)
@@ -58,6 +67,87 @@ void TreeViewOptions::set_name_column_hidden(bool b)
     settings->beginGroup(S_RAWTREEVIEW);
     settings->beginGroup(S_COLUMNSHIDDEN);
     settings->setValue(MODEL_HEADER_NAME, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_nixtype_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_NIXTYPE, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_storagetype_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_STORAGETYPE, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_datatype_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_DATATYPE, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_shape_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_SHAPE, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_id_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_ID, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_createdat_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_CREATEDAT, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_updatedat_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_UPDATEDAT, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_value_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_VALUE, !b);
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::set_uncertainty_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_UNCERTAINTY, !b);
     settings->endGroup();
     settings->endGroup();
 }

--- a/options/viewoptions/TreeViewOptions.cpp
+++ b/options/viewoptions/TreeViewOptions.cpp
@@ -1,23 +1,65 @@
 #include "TreeViewOptions.hpp"
 #include "ui_TreeViewOptions.h"
 #include "common/Common.hpp"
+#include "views/RawTreeView.hpp"
 
 TreeViewOptions::TreeViewOptions(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::TreeViewOptions)
 {
     ui->setupUi(this);
+    settings = new QSettings;
 
-    ui->checkBox_1->setText(QString(MODEL_HEADER_NAME));
-    ui->checkBox_2->setText(QString(MODEL_HEADER_NIXTYPE));
-    ui->checkBox_3->setText(QString(MODEL_HEADER_STORAGETYPE));
-    ui->checkBox_4->setText(QString(MODEL_HEADER_DATATYPE));
-    ui->checkBox_5->setText(QString(MODEL_HEADER_SHAPE));
-    ui->checkBox_6->setText(QString(MODEL_HEADER_ID));
-    ui->checkBox_7->setText(QString(MODEL_HEADER_CREATEDAT));
-    ui->checkBox_8->setText(QString(MODEL_HEADER_UPDATEDAT));
-    ui->checkBox_9->setText(QString(MODEL_HEADER_VALUE));
-    ui->checkBox_10->setText(QString(MODEL_HEADER_UNERTAINTY));
+    ui->checkBox_name->setText(QString(MODEL_HEADER_NAME));
+    ui->checkBox_nixtype->setText(QString(MODEL_HEADER_NIXTYPE));
+    ui->checkBox_storagetype->setText(QString(MODEL_HEADER_STORAGETYPE));
+    ui->checkBox_datatype->setText(QString(MODEL_HEADER_DATATYPE));
+    ui->checkBox_shape->setText(QString(MODEL_HEADER_SHAPE));
+    ui->checkBox_id->setText(QString(MODEL_HEADER_ID));
+    ui->checkBox_createdat->setText(QString(MODEL_HEADER_CREATEDAT));
+    ui->checkBox_updatedat->setText(QString(MODEL_HEADER_UPDATEDAT));
+    ui->checkBox_value->setText(QString(MODEL_HEADER_VALUE));
+    ui->checkBox_uncertainty->setText(QString(MODEL_HEADER_UNERTAINTY));
+
+    load_settings();
+
+    connect_widgets();
+}
+
+void TreeViewOptions::load_settings()
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+
+    QStringList default_hidden_columns = RawTreeView::get_default_hidden_columns();
+
+    ui->checkBox_name->setChecked(!(settings->value(MODEL_HEADER_NAME, default_hidden_columns.contains(MODEL_HEADER_NAME) ? true : false).toBool()));
+    ui->checkBox_nixtype->setChecked(!(settings->value(MODEL_HEADER_NIXTYPE, default_hidden_columns.contains(MODEL_HEADER_NIXTYPE) ? true : false).toBool()));
+    ui->checkBox_storagetype->setChecked(!(settings->value(MODEL_HEADER_STORAGETYPE, default_hidden_columns.contains(MODEL_HEADER_STORAGETYPE) ? true : false).toBool()));
+    ui->checkBox_datatype->setChecked(!(settings->value(MODEL_HEADER_DATATYPE, default_hidden_columns.contains(MODEL_HEADER_DATATYPE) ? true : false).toBool()));
+    ui->checkBox_shape->setChecked(!(settings->value(MODEL_HEADER_SHAPE, default_hidden_columns.contains(MODEL_HEADER_SHAPE) ? true : false).toBool()));
+    ui->checkBox_id->setChecked(!(settings->value(MODEL_HEADER_ID, default_hidden_columns.contains(MODEL_HEADER_ID) ? true : false).toBool()));
+    ui->checkBox_createdat->setChecked(!(settings->value(MODEL_HEADER_CREATEDAT, default_hidden_columns.contains(MODEL_HEADER_CREATEDAT) ? true : false).toBool()));
+    ui->checkBox_updatedat->setChecked(!(settings->value(MODEL_HEADER_UPDATEDAT, default_hidden_columns.contains(MODEL_HEADER_UPDATEDAT) ? true : false).toBool()));
+    ui->checkBox_value->setChecked(!(settings->value(MODEL_HEADER_VALUE, default_hidden_columns.contains(MODEL_HEADER_VALUE) ? true : false).toBool()));
+    ui->checkBox_uncertainty->setChecked(!(settings->value(MODEL_HEADER_UNERTAINTY, default_hidden_columns.contains(MODEL_HEADER_UNERTAINTY) ? true : false).toBool()));
+
+    settings->endGroup();
+    settings->endGroup();
+}
+
+void TreeViewOptions::connect_widgets()
+{
+    QObject::connect(ui->checkBox_name, SIGNAL(clicked(bool)), this, SLOT(set_name_column_hidden(bool)));
+}
+
+void TreeViewOptions::set_name_column_hidden(bool b)
+{
+    settings->beginGroup(S_RAWTREEVIEW);
+    settings->beginGroup(S_COLUMNSHIDDEN);
+    settings->setValue(MODEL_HEADER_NAME, !b);
+    settings->endGroup();
+    settings->endGroup();
 }
 
 TreeViewOptions::~TreeViewOptions()

--- a/options/viewoptions/TreeViewOptions.cpp
+++ b/options/viewoptions/TreeViewOptions.cpp
@@ -1,0 +1,26 @@
+#include "TreeViewOptions.hpp"
+#include "ui_TreeViewOptions.h"
+#include "common/Common.hpp"
+
+TreeViewOptions::TreeViewOptions(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::TreeViewOptions)
+{
+    ui->setupUi(this);
+
+    ui->checkBox_1->setText(QString(MODEL_HEADER_NAME));
+    ui->checkBox_2->setText(QString(MODEL_HEADER_NIXTYPE));
+    ui->checkBox_3->setText(QString(MODEL_HEADER_STORAGETYPE));
+    ui->checkBox_4->setText(QString(MODEL_HEADER_DATATYPE));
+    ui->checkBox_5->setText(QString(MODEL_HEADER_SHAPE));
+    ui->checkBox_6->setText(QString(MODEL_HEADER_ID));
+    ui->checkBox_7->setText(QString(MODEL_HEADER_CREATEDAT));
+    ui->checkBox_8->setText(QString(MODEL_HEADER_UPDATEDAT));
+    ui->checkBox_9->setText(QString(MODEL_HEADER_VALUE));
+    ui->checkBox_10->setText(QString(MODEL_HEADER_UNERTAINTY));
+}
+
+TreeViewOptions::~TreeViewOptions()
+{
+    delete ui;
+}

--- a/options/viewoptions/TreeViewOptions.cpp
+++ b/options/viewoptions/TreeViewOptions.cpp
@@ -69,6 +69,7 @@ void TreeViewOptions::set_name_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_NAME, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_nixtype_column_hidden(bool b)
@@ -78,6 +79,7 @@ void TreeViewOptions::set_nixtype_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_NIXTYPE, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_storagetype_column_hidden(bool b)
@@ -87,6 +89,7 @@ void TreeViewOptions::set_storagetype_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_STORAGETYPE, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_datatype_column_hidden(bool b)
@@ -96,6 +99,7 @@ void TreeViewOptions::set_datatype_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_DATATYPE, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_shape_column_hidden(bool b)
@@ -105,6 +109,7 @@ void TreeViewOptions::set_shape_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_SHAPE, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_id_column_hidden(bool b)
@@ -114,6 +119,7 @@ void TreeViewOptions::set_id_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_ID, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_createdat_column_hidden(bool b)
@@ -123,6 +129,7 @@ void TreeViewOptions::set_createdat_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_CREATEDAT, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_updatedat_column_hidden(bool b)
@@ -132,6 +139,7 @@ void TreeViewOptions::set_updatedat_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_UPDATEDAT, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_value_column_hidden(bool b)
@@ -141,6 +149,7 @@ void TreeViewOptions::set_value_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_VALUE, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 void TreeViewOptions::set_uncertainty_column_hidden(bool b)
@@ -150,6 +159,7 @@ void TreeViewOptions::set_uncertainty_column_hidden(bool b)
     settings->setValue(MODEL_HEADER_UNCERTAINTY, !b);
     settings->endGroup();
     settings->endGroup();
+    emit_rtv_column_display_changed();
 }
 
 TreeViewOptions::~TreeViewOptions()

--- a/options/viewoptions/TreeViewOptions.hpp
+++ b/options/viewoptions/TreeViewOptions.hpp
@@ -28,6 +28,9 @@ public slots:
     void set_value_column_hidden(bool b);
     void set_uncertainty_column_hidden(bool b);
 
+signals:
+    void emit_rtv_column_display_changed();
+
 private:
     Ui::TreeViewOptions *ui;
     QSettings *settings;

--- a/options/viewoptions/TreeViewOptions.hpp
+++ b/options/viewoptions/TreeViewOptions.hpp
@@ -1,0 +1,22 @@
+#ifndef VIEWOPTIONS_HPP
+#define VIEWOPTIONS_HPP
+
+#include <QWidget>
+
+namespace Ui {
+class TreeViewOptions;
+}
+
+class TreeViewOptions : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TreeViewOptions(QWidget *parent = 0);
+    ~TreeViewOptions();
+
+private:
+    Ui::TreeViewOptions *ui;
+};
+
+#endif // VIEWOPTIONS_HPP

--- a/options/viewoptions/TreeViewOptions.hpp
+++ b/options/viewoptions/TreeViewOptions.hpp
@@ -18,6 +18,15 @@ public:
 
 public slots:
     void set_name_column_hidden(bool b);
+    void set_nixtype_column_hidden(bool b);
+    void set_storagetype_column_hidden(bool b);
+    void set_datatype_column_hidden(bool b);
+    void set_shape_column_hidden(bool b);
+    void set_id_column_hidden(bool b);
+    void set_createdat_column_hidden(bool b);
+    void set_updatedat_column_hidden(bool b);
+    void set_value_column_hidden(bool b);
+    void set_uncertainty_column_hidden(bool b);
 
 private:
     Ui::TreeViewOptions *ui;

--- a/options/viewoptions/TreeViewOptions.hpp
+++ b/options/viewoptions/TreeViewOptions.hpp
@@ -2,6 +2,7 @@
 #define VIEWOPTIONS_HPP
 
 #include <QWidget>
+#include <QSettings>
 
 namespace Ui {
 class TreeViewOptions;
@@ -15,8 +16,14 @@ public:
     explicit TreeViewOptions(QWidget *parent = 0);
     ~TreeViewOptions();
 
+public slots:
+    void set_name_column_hidden(bool b);
+
 private:
     Ui::TreeViewOptions *ui;
+    QSettings *settings;
+    void load_settings();
+    void connect_widgets();
 };
 
 #endif // VIEWOPTIONS_HPP

--- a/options/viewoptions/TreeViewOptions.ui
+++ b/options/viewoptions/TreeViewOptions.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TreeViewOptions</class>
+ <widget class="QWidget" name="TreeViewOptions">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>491</width>
+    <height>409</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Visible Columns</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_1">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_2">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_3">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_4">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_5">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_6">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_7">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_8">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_9">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_10">
+     <property name="text">
+      <string>CheckBox</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/options/viewoptions/TreeViewOptions.ui
+++ b/options/viewoptions/TreeViewOptions.ui
@@ -28,70 +28,70 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_1">
+    <widget class="QCheckBox" name="checkBox_name">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_2">
+    <widget class="QCheckBox" name="checkBox_nixtype">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_3">
+    <widget class="QCheckBox" name="checkBox_storagetype">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_4">
+    <widget class="QCheckBox" name="checkBox_datatype">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_5">
+    <widget class="QCheckBox" name="checkBox_shape">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_6">
+    <widget class="QCheckBox" name="checkBox_id">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_7">
+    <widget class="QCheckBox" name="checkBox_createdat">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_8">
+    <widget class="QCheckBox" name="checkBox_updatedat">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_9">
+    <widget class="QCheckBox" name="checkBox_value">
      <property name="text">
       <string>CheckBox</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_10">
+    <widget class="QCheckBox" name="checkBox_uncertainty">
      <property name="text">
       <string>CheckBox</string>
      </property>

--- a/views/RawTreeView.cpp
+++ b/views/RawTreeView.cpp
@@ -26,7 +26,8 @@ void RawTreeView::set_proxy_model(NixProxyModel *proxy_model)
 
     ui->treeView->setModel(nix_proxy_model);
     ui->treeView->setSelectionBehavior(QAbstractItemView::SelectRows);
-    hidden_columns = {5, 6, 7, 10};
+    fixed_hidden_columns = {10};
+    set_hidden_columns({5, 6, 7});
     for (int entry : hidden_columns)
         ui->treeView->setColumnHidden(entry, true);
     ui->treeView->sortByColumn(0, Qt::AscendingOrder);
@@ -34,9 +35,17 @@ void RawTreeView::set_proxy_model(NixProxyModel *proxy_model)
 }
 
 // slots
-void RawTreeView::resize_to_content(QModelIndex) {
+void RawTreeView::resize_to_content(QModelIndex)
+{
     for (int c = 0; c<nix_proxy_model->columnCount();c++)
         ui->treeView->resizeColumnToContents(c);
+}
+
+void RawTreeView::set_hidden_columns(std::vector<int> cols)
+{
+    for(int c : fixed_hidden_columns)
+        cols.push_back(c);
+    hidden_columns = cols;
 }
 
 // getter

--- a/views/RawTreeView.cpp
+++ b/views/RawTreeView.cpp
@@ -5,6 +5,11 @@
 #include "common/Common.hpp"
 #include <qdebug.h>
 
+QStringList RawTreeView::DEFAULT_HIDDEN_COLUMNS = {MODEL_HEADER_ID,
+                                                   MODEL_HEADER_CREATEDAT,
+                                                   MODEL_HEADER_UPDATEDAT,
+                                                   MODEL_HEADER_ROOTCHILDLINK};
+
 RawTreeView::RawTreeView(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::RawTreeView)
@@ -13,11 +18,6 @@ RawTreeView::RawTreeView(QWidget *parent) :
     filter_mode = 0;
 
     nix_proxy_model = nullptr;
-
-    default_hidden_columns = {MODEL_HEADER_ID,
-                              MODEL_HEADER_CREATEDAT,
-                              MODEL_HEADER_UPDATEDAT,
-                              MODEL_HEADER_ROOTCHILDLINK};
 
     settings = new QSettings();
 }
@@ -49,12 +49,12 @@ void RawTreeView::resize_to_content(QModelIndex)
 void RawTreeView::hide_columns()
 {
     settings->beginGroup(S_RAWTREEVIEW);
-    settings->beginGroup(S_COLUMNS);
+    settings->beginGroup(S_COLUMNSHIDDEN);
     RowStrings headers = static_cast<NixDataModel*>(nix_proxy_model->sourceModel())->get_headers();
     if (!(nix_proxy_model == nullptr))
         for (int i = 0; i < headers.size(); ++i)
         {
-            bool hidden = settings->value(headers[i], default_hidden_columns.contains(headers[i]) ? true : false).toBool();
+            bool hidden = settings->value(headers[i], RawTreeView::DEFAULT_HIDDEN_COLUMNS.contains(headers[i]) ? true : false).toBool();
             ui->treeView->setColumnHidden(i, hidden);
         }
     settings->endGroup();

--- a/views/RawTreeView.cpp
+++ b/views/RawTreeView.cpp
@@ -19,6 +19,8 @@ RawTreeView::RawTreeView(QWidget *parent) :
 
     nix_proxy_model = nullptr;
 
+    current_depth = 0;
+
     settings = new QSettings();
 }
 
@@ -39,11 +41,43 @@ void RawTreeView::set_proxy_model(NixProxyModel *proxy_model)
 
 }
 
+int RawTreeView::calc_depth_from_qml(QModelIndex qml)
+{
+    QModelIndex index = qml;
+    int depth = 0;
+    while (index.parent().isValid())
+    {
+        index = index.parent();
+        ++depth;
+    }
+    return depth;
+}
+
 // slots
 void RawTreeView::resize_to_content(QModelIndex)
 {
     for (int c = 0; c<nix_proxy_model->columnCount();c++)
         ui->treeView->resizeColumnToContents(c);
+}
+
+void RawTreeView::expand_collapse(QString)
+{
+    ui->treeView->expandToDepth(current_depth);
+}
+
+void RawTreeView::expand_collapse(bool)
+{
+    ui->treeView->expandToDepth(current_depth);
+}
+
+void RawTreeView::set_current_depth_expanded(QModelIndex qml)
+{
+    current_depth = calc_depth_from_qml(qml);
+}
+
+void RawTreeView::set_current_depth_collapsed(QModelIndex qml)
+{
+    current_depth = calc_depth_from_qml(qml) - 1;
 }
 
 void RawTreeView::hide_columns()

--- a/views/RawTreeView.cpp
+++ b/views/RawTreeView.cpp
@@ -59,6 +59,8 @@ void RawTreeView::hide_columns()
         }
     settings->endGroup();
     settings->endGroup();
+
+   resize_to_content(QModelIndex());
 }
 
 // getter

--- a/views/RawTreeView.hpp
+++ b/views/RawTreeView.hpp
@@ -25,6 +25,7 @@ public:
 
 public slots:
     void resize_to_content(QModelIndex);
+    void set_hidden_columns(std::vector<int> cols);
 
 signals:
     void item_found(QVariant);
@@ -46,6 +47,7 @@ private:
     nix::File nix_file;
     NixProxyModel *nix_proxy_model;
     std::vector<int> hidden_columns;
+    std::vector<int> fixed_hidden_columns;
 
 public:
     QTreeView* get_tree_view();

--- a/views/RawTreeView.hpp
+++ b/views/RawTreeView.hpp
@@ -11,6 +11,7 @@
 #include "filter/NixProxyModel.hpp"
 #include <QSettings>
 
+
 namespace Ui {
 class RawTreeView;
 }
@@ -47,12 +48,13 @@ private:
     Ui::RawTreeView* ui;
     nix::File nix_file;
     NixProxyModel *nix_proxy_model;
-    QStringList default_hidden_columns;
+    static QStringList DEFAULT_HIDDEN_COLUMNS;
 
     QSettings *settings;
 
 public:
     QTreeView* get_tree_view();
     void  set_proxy_model(NixProxyModel *proxy_model);
+    static QStringList get_default_hidden_columns() {return DEFAULT_HIDDEN_COLUMNS; }
 };
 #endif // RAWTREEVIEW_HPP

--- a/views/RawTreeView.hpp
+++ b/views/RawTreeView.hpp
@@ -28,6 +28,10 @@ public:
 public slots:
     void resize_to_content(QModelIndex);
     void hide_columns();
+    void expand_collapse(QString);
+    void expand_collapse(bool);
+    void set_current_depth_expanded(QModelIndex);
+    void set_current_depth_collapsed(QModelIndex);
 
 signals:
     void item_found(QVariant);
@@ -49,6 +53,9 @@ private:
     nix::File nix_file;
     NixProxyModel *nix_proxy_model;
     static QStringList DEFAULT_HIDDEN_COLUMNS;
+
+    int current_depth;
+    int calc_depth_from_qml(QModelIndex);
 
     QSettings *settings;
 

--- a/views/RawTreeView.hpp
+++ b/views/RawTreeView.hpp
@@ -9,6 +9,7 @@
 #include <QComboBox>
 #include "model/NixDataModel.hpp"
 #include "filter/NixProxyModel.hpp"
+#include <QSettings>
 
 namespace Ui {
 class RawTreeView;
@@ -25,7 +26,7 @@ public:
 
 public slots:
     void resize_to_content(QModelIndex);
-    void set_hidden_columns(std::vector<int> cols);
+    void hide_columns();
 
 signals:
     void item_found(QVariant);
@@ -46,8 +47,9 @@ private:
     Ui::RawTreeView* ui;
     nix::File nix_file;
     NixProxyModel *nix_proxy_model;
-    std::vector<int> hidden_columns;
-    std::vector<int> fixed_hidden_columns;
+    QStringList default_hidden_columns;
+
+    QSettings *settings;
 
 public:
     QTreeView* get_tree_view();


### PR DESCRIPTION
Configuration File:
resolves #36
Using QSettings.  Built-in QT class, which manages config files in a cross-plattform manner. Very easy to use and thus far very reliable. For proper use, corporation and application names had to be set (g-node, nixview), which are used as folder names (see http://doc.qt.io/qt-5/qsettings.html#platform-specific-notes ).

resolves #33 :
added options menu with nested tabs. User can decide which columns to use in tree view. If selection is changed, config file is changed and view refreshed according to config file.

resolves #40 :
treeview remembers the depth according to the _last_ expended or collapsed item. When filtering, _all_ items are expanded to that level.

resolves #35 